### PR TITLE
Fix white-on-white buttons on iPhone

### DIFF
--- a/css/admintool.css
+++ b/css/admintool.css
@@ -100,6 +100,7 @@ body {
     font-size: 100%;
     margin: 4px;
     background-color: white;
+    color: black;
     border: 1px solid #AAA;
     border-radius: 6px;
     padding: 2px 8px;


### PR DESCRIPTION
On iPhone, the default user-agent stylesheet sets buttons to white text and background `-apple-system-blue`. When changing the background to white, we also need to set the foreground color, or it'll be white on white.

![Simulator Screenshot - iPhone 15 Pro - 2023-12-23 at 14 31 46](https://github.com/iftechfoundation/ifarchive-admintool/assets/96150/d62d143f-6566-4b27-8f3c-6758809f3fae)
