### PR TITLE
Fix deleting files in Docker

### DIFF
--- a/docker/upload-file.sh
+++ b/docker/upload-file.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 FILE=${@: -1}
 docker compose cp $FILE web:/var/ifarchive/incoming
+docker compose exec web chown -R www-data /var/ifarchive/incoming
 
 # pop last argument https://stackoverflow.com/a/26163980/54829
 set -- "${@:1:$(($#-1))}"


### PR DESCRIPTION
Fixes #55

When we upload files to Docker with `docker compose cp`, they're created as `root`. We have to `chown` them to `www-data` to allow the admintool to work with them.